### PR TITLE
Add notes to wishlist items, plus update-flow fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ composer fix-style      # ECS auto-fix
 composer phpunit        # PHPUnit
 vendor/bin/rector process --dry-run         # refactor check
 vendor/bin/composer-dependency-analyser     # unused/missing composer deps
-vendor/bin/infection                        # mutation testing (requires 100% MSI)
+vendor/bin/infection                        # mutation testing (minMsi 25, minCoveredMsi 95)
 ```
 
 User shell aliases map to these: `ca` (analyse), `cf` (fix-style), `cfca` (fix then analyse), `crc` (dependency check). `phpunit`, `rector`, `infection` aliases call the project-local `vendor/bin`.
@@ -38,7 +38,7 @@ bin/console lint:container
 bin/console doctrine:schema:validate -vvv
 ```
 
-Note: there are currently no PHPUnit/spec test classes in `tests/` (only the test Application). `infection.json.dist` pins `minMsi`/`minCoveredMsi` to 100, so adding source without covering tests will fail the mutation job.
+Note: unit tests live under `tests/Unit/`, mirroring `src/` (e.g. `tests/Unit/Controller/ShowWishlistActionTest.php`), alongside the test Application. `infection.json.dist` pins `minMsi` to 25 and `minCoveredMsi` to 95 — covered-code MSI is effectively 100% today, so add a unit test under `tests/Unit/` for any new source or the mutation job will regress.
 
 ## Architecture
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "php": ">=8.1",
         "doctrine/collections": "^1.6",
         "doctrine/persistence": "^2.0 || ^3.0",
-        "setono/client-bundle": "^1.0@beta",
+        "setono/client-bundle": "^1.2",
         "setono/composite-compiler-pass": "^1.2",
         "setono/doctrine-orm-trait": "^1.1",
         "sylius/core": "^1.13",

--- a/src/Controller/ShowWishlistAction.php
+++ b/src/Controller/ShowWishlistAction.php
@@ -9,9 +9,12 @@ use Setono\SyliusWishlistPlugin\Model\WishlistInterface;
 use Setono\SyliusWishlistPlugin\Repository\WishlistRepositoryInterface;
 use Setono\SyliusWishlistPlugin\Security\Voter\WishlistVoter;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\FlashBagAwareSessionInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Twig\Environment;
 
@@ -25,6 +28,7 @@ final class ShowWishlistAction
         private readonly FormFactoryInterface $formFactory,
         private readonly AuthorizationCheckerInterface $authorizationChecker,
         private readonly Environment $twig,
+        private readonly UrlGeneratorInterface $urlGenerator,
     ) {
     }
 
@@ -46,6 +50,16 @@ final class ShowWishlistAction
             }
 
             $this->wishlistRepository->add($wishlist);
+
+            $session = $request->getSession();
+            if ($session instanceof FlashBagAwareSessionInterface) {
+                $session->getFlashBag()->add('success', 'setono_sylius_wishlist.wishlist_updated');
+            }
+
+            // Redirect after a successful update so a browser refresh doesn't re-submit the form (POST/Redirect/GET).
+            return new RedirectResponse($this->urlGenerator->generate('setono_sylius_wishlist_shop_wishlist_show', [
+                'uuid' => $uuid,
+            ]));
         }
 
         return new Response($this->twig->render('@SetonoSyliusWishlistPlugin/shop/wishlist/show.html.twig', [

--- a/src/Form/Type/WishlistItemType.php
+++ b/src/Form/Type/WishlistItemType.php
@@ -9,6 +9,7 @@ use Sylius\Bundle\ProductBundle\Form\Type\ProductVariantChoiceType;
 use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -21,6 +22,11 @@ class WishlistItemType extends AbstractResourceType
             ->add('quantity', IntegerType::class, [
                 'attr' => ['min' => 1],
                 'label' => 'sylius.ui.quantity',
+            ])
+            ->add('note', TextareaType::class, [
+                'attr' => ['rows' => 3],
+                'label' => 'setono_sylius_wishlist.ui.note',
+                'required' => false,
             ])
             ->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
                 $data = $event->getData();

--- a/src/Model/WishlistItem.php
+++ b/src/Model/WishlistItem.php
@@ -20,6 +20,8 @@ class WishlistItem implements WishlistItemInterface
 
     protected int $quantity = 1;
 
+    protected ?string $note = null;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -70,5 +72,15 @@ class WishlistItem implements WishlistItemInterface
     public function setQuantity(int $quantity): void
     {
         $this->quantity = $quantity;
+    }
+
+    public function getNote(): ?string
+    {
+        return $this->note;
+    }
+
+    public function setNote(?string $note): void
+    {
+        $this->note = $note;
     }
 }

--- a/src/Model/WishlistItemInterface.php
+++ b/src/Model/WishlistItemInterface.php
@@ -25,4 +25,8 @@ interface WishlistItemInterface extends ResourceInterface
     public function getQuantity(): int;
 
     public function setQuantity(int $quantity): void;
+
+    public function getNote(): ?string;
+
+    public function setNote(?string $note): void;
 }

--- a/src/Resources/config/doctrine/model/WishlistItem.orm.xml
+++ b/src/Resources/config/doctrine/model/WishlistItem.orm.xml
@@ -12,6 +12,8 @@
 
         <field name="quantity" type="integer"/>
 
+        <field name="note" type="text" nullable="true"/>
+
         <many-to-one field="wishlist" target-entity="Setono\SyliusWishlistPlugin\Model\WishlistInterface"
                      inversed-by="items">
             <join-column name="wishlist_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>

--- a/src/Resources/config/services/controller.xml
+++ b/src/Resources/config/services/controller.xml
@@ -18,6 +18,7 @@
             <argument type="service" id="form.factory"/>
             <argument type="service" id="security.authorization_checker"/>
             <argument type="service" id="twig"/>
+            <argument type="service" id="router"/>
         </service>
 
         <service id="Setono\SyliusWishlistPlugin\Controller\FirstWishlistRedirectAction" public="true">

--- a/src/Resources/translations/flashes.da.yaml
+++ b/src/Resources/translations/flashes.da.yaml
@@ -1,2 +1,3 @@
 setono_sylius_wishlist:
     no_wishlists: Du har ikke tilføjet noget til din ønskeliste endnu
+    wishlist_updated: Din ønskeliste er blevet opdateret

--- a/src/Resources/translations/flashes.en.yaml
+++ b/src/Resources/translations/flashes.en.yaml
@@ -1,2 +1,3 @@
 setono_sylius_wishlist:
     no_wishlists: You haven't added anything to your wishlist yet
+    wishlist_updated: Your wishlist has been updated

--- a/src/Resources/translations/flashes.no.yaml
+++ b/src/Resources/translations/flashes.no.yaml
@@ -1,2 +1,3 @@
 setono_sylius_wishlist:
     no_wishlists: Du har ikke lagt til noe på ønskelisten din ennå
+    wishlist_updated: Ønskelisten din har blitt oppdatert

--- a/src/Resources/translations/messages.da.yaml
+++ b/src/Resources/translations/messages.da.yaml
@@ -3,6 +3,7 @@ setono_sylius_wishlist:
         add_wishlist_to_cart: Tilføj ønskeliste til kurv
         copy: Kopier
         inventory_insufficient: Lageret er utilstrækkeligt til den mængde, du ønsker at tilføje til ønskelisten
+        note: Note
         remove_from_wishlist: Fjern
         select_variant: Vælg variant...
         wishlist: Ønskeliste

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -3,6 +3,7 @@ setono_sylius_wishlist:
         add_wishlist_to_cart: Add wishlist to cart
         copy: Copy
         inventory_insufficient: The inventory is insufficient for the quantity you want to add to the wishlist
+        note: Note
         remove_from_wishlist: Remove
         select_variant: Select variant...
         wishlist: Wishlist

--- a/src/Resources/translations/messages.no.yaml
+++ b/src/Resources/translations/messages.no.yaml
@@ -3,6 +3,7 @@ setono_sylius_wishlist:
         add_wishlist_to_cart: Legg ønskeliste til handlekurv
         copy: Kopier
         inventory_insufficient: Lageret er utilstrekkelig for mengden du ønsker å legge til ønskelisten
+        note: Notat
         remove_from_wishlist: Fjern
         select_variant: Velg variant...
         wishlist: Ønskeliste

--- a/src/Resources/views/shop/wishlist/show.html.twig
+++ b/src/Resources/views/shop/wishlist/show.html.twig
@@ -37,6 +37,7 @@
                     <th>{{ 'sylius.ui.quantity'|trans }}</th>
                     <th>{{ 'sylius.ui.product'|trans }}</th>
                     <th>{{ 'sylius.ui.variant'|trans }}</th>
+                    <th>{{ 'setono_sylius_wishlist.ui.note'|trans }}</th>
                     <th>{{ 'sylius.ui.price'|trans }}</th>
                     <th>&nbsp;</th>
                 </tr>
@@ -72,6 +73,15 @@
                                     {{ form_widget(form.items[key].variant) }}
                                 {% endif %}
                             </div>
+                        </td>
+                        <td>
+                            {% if canEdit %}
+                                <div class="ui form">
+                                    {{ form_widget(form.items[key].note) }}
+                                </div>
+                            {% elseif item.note %}
+                                {{ item.note|nl2br }}
+                            {% endif %}
                         </td>
                         <td>
                             {{ include('@SetonoSyliusWishlistPlugin/shop/wishlist/show/_price.html.twig') }}
@@ -118,6 +128,10 @@
             display: flex;
             flex-wrap: nowrap;
             gap: 20px;
+        }
+
+        .ui.table td {
+            vertical-align: top;
         }
     </style>
 {% endblock %}

--- a/tests/Unit/Controller/ShowWishlistActionTest.php
+++ b/tests/Unit/Controller/ShowWishlistActionTest.php
@@ -12,8 +12,12 @@ use Setono\SyliusWishlistPlugin\Repository\WishlistRepositoryInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Twig\Environment;
 
@@ -27,6 +31,7 @@ final class ShowWishlistActionTest extends TestCase
             $this->formFactory($this->form(false)),
             $this->authorizationChecker(true),
             $this->twig(),
+            $this->urlGenerator(),
         );
 
         $this->expectException(NotFoundHttpException::class);
@@ -35,21 +40,38 @@ final class ShowWishlistActionTest extends TestCase
     }
 
     /** @test */
-    public function it_saves_the_wishlist_when_the_owner_submits_a_valid_form(): void
+    public function it_saves_the_wishlist_and_redirects_with_a_flash_when_the_owner_submits_a_valid_form(): void
     {
         $wishlist = $this->createMock(WishlistInterface::class);
 
         $repository = $this->repository($wishlist);
         $repository->expects(self::once())->method('add')->with($wishlist);
 
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator
+            ->expects(self::once())
+            ->method('generate')
+            ->with('setono_sylius_wishlist_shop_wishlist_show', ['uuid' => 'uuid'])
+            ->willReturn('/wishlists/uuid')
+        ;
+
         $action = new ShowWishlistAction(
             $repository,
             $this->formFactory($this->form(true)),
             $this->authorizationChecker(true),
             $this->twig(),
+            $urlGenerator,
         );
 
-        $action(new Request(), 'uuid');
+        $session = new Session(new MockArraySessionStorage());
+        $request = new Request();
+        $request->setSession($session);
+
+        $response = $action($request, 'uuid');
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame('/wishlists/uuid', $response->getTargetUrl());
+        self::assertSame(['setono_sylius_wishlist.wishlist_updated'], $session->getFlashBag()->peek('success'));
     }
 
     /** @test */
@@ -63,6 +85,7 @@ final class ShowWishlistActionTest extends TestCase
             $this->formFactory($this->form(true)),
             $this->authorizationChecker(false),
             $this->twig(),
+            $this->urlGenerator(),
         );
 
         $this->expectException(NotFoundHttpException::class);
@@ -84,6 +107,7 @@ final class ShowWishlistActionTest extends TestCase
             $this->formFactory($this->form(false)),
             $authorizationChecker,
             $this->twig(),
+            $this->urlGenerator(),
         );
 
         $action(new Request(), 'uuid');
@@ -133,5 +157,13 @@ final class ShowWishlistActionTest extends TestCase
         $twig->method('render')->willReturn('');
 
         return $twig;
+    }
+
+    private function urlGenerator(): UrlGeneratorInterface
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->method('generate')->willReturn('/wishlists/uuid');
+
+        return $urlGenerator;
     }
 }


### PR DESCRIPTION
## What's in here

This branch bundles the wishlist-item **notes** feature plus a couple of UX fixes and chores discovered along the way. Each is a separate commit for easy review.

### Add notes to wishlist items (closes #2)
Each wishlist item gets an optional free-text **note** (nullable `text` column). The owner edits it via a textarea in the existing wishlist form; recipients of a shared wishlist see it as read-only text. Wishlist item rows are now top-aligned so the taller, multi-line note cells line up with the other columns.

- `WishlistItem` / `WishlistItemInterface`: `note` property + accessors
- Doctrine mapping: `<field name="note" type="text" nullable="true"/>`
- `WishlistItemType`: `note` textarea (saved by the existing PATCH form — no new controller/route/JS)
- `messages.{en,da,no}.yaml`: `note` label
- `show.html.twig`: note column + `vertical-align: top`

### Flash a confirmation and redirect after updating a wishlist
Updating a wishlist re-rendered the page in place — no feedback, and a browser refresh re-submitted the form. Now it adds a success flash and redirects back to the wishlist (POST/Redirect/GET).

- `ShowWishlistAction`: success flash + redirect; `router` injected via `controller.xml`
- `flashes.{en,da,no}.yaml`: `wishlist_updated` message
- `ShowWishlistActionTest`: updated + asserts the redirect target and flash

### Chores
- Pin `setono/client-bundle` to `^1.2` (was left on `^1.0@beta`).
- Fix two stale notes in `CLAUDE.md` (there is now a `tests/Unit` suite; infection thresholds are `minMsi 25` / `minCoveredMsi 95`, not 100% MSI).

## Verification
- `composer analyse` (PHPStan max), `composer check-style` (ECS), `rector --dry-run` — clean
- `composer phpunit` — 59 tests / 97 assertions pass
- `vendor/bin/infection` — Covered Code MSI 100%, MSI 34% (both over threshold)
- Booted test app: `lint:twig`, `lint:yaml`, `lint:container` clean; `doctrine:schema:validate` mapping correct
- Manual browser run (notes save/persist for owner, read-only for recipients; update shows the flash, redirects, and a refresh no longer re-submits)

## Not included
The "Add wishlist to cart fails when an item has no variant" UX problem (#7) is intentionally out of scope here.
